### PR TITLE
Update contact link to open Gmail composer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,6 +8,7 @@ import { Linkedin } from 'lucide-react';
 const Footer = () => {
   const currentYear = new Date().getFullYear();
   const companyName = 'ConversAILabs';
+  const emailAddress = 'dev@conversailabs.com';
 
   return (
     <footer className="bg-accent py-12">
@@ -38,7 +39,12 @@ const Footer = () => {
                 </a>
               </li>
               <li>
-                <a href="#" className="text-muted-foreground hover:text-primary">
+                <a 
+                  href={`https://mail.google.com/mail/?view=cm&fs=1&to=${emailAddress}`}
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground hover:text-primary"
+                >
                   Contact
                 </a>
               </li>


### PR DESCRIPTION
feat: Update contact link to open Gmail composer

- Replace mailto link with direct Gmail composer URL
- Pre-populate the recipient field with dev@conversailabs.com
- Set link to open in new tab with appropriate security attributes